### PR TITLE
fix: Remove duplicate DELETE route with incorrect action in nested resources

### DIFF
--- a/lib/ruby_routes/router.rb
+++ b/lib/ruby_routes/router.rb
@@ -63,7 +63,6 @@ module RubyRoutes
         get "/#{plural}/:id/#{nested_plural}/:nested_id/edit", options.merge(to: "#{nested_plural}#edit")
         put "/#{plural}/:id/#{nested_plural}/:nested_id", options.merge(to: "#{nested_plural}#update")
         patch "/#{plural}/:id/#{nested_plural}/:nested_id", options.merge(to: "#{nested_plural}#update")
-        delete "/#{plural}/:id/#{nested_plural}/:nested_id", options.merge(to: "#{nested_plural}#update")
         delete "/#{plural}/:id/#{nested_plural}/:nested_id", options.merge(to: "#{nested_plural}#destroy")
       end
 


### PR DESCRIPTION
- Fixed bug where nested resources generated two DELETE routes for the same path
- First DELETE route incorrectly mapped to 'update' action instead of 'destroy'
- Now only generates one DELETE route that correctly maps to 'destroy' action
- Added a comprehensive test to verify that DELETE routes only map to the destroy action
- Ensures proper RESTful routing behavior for nested resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected DELETE behavior for nested resources: DELETE requests now properly trigger deletion instead of update, removing a conflicting route and preventing unintended updates when deleting nested items (e.g., comments under posts).

- Tests
  - Added tests to verify nested resource routing, including that DELETE maps exclusively to the destroy action and that standard nested routes (index, new, create, show, edit, update) are correctly generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->